### PR TITLE
Leaving game - unmute players

### DIFF
--- a/src/GameManager.js
+++ b/src/GameManager.js
@@ -15,7 +15,7 @@ class GameManager {
   }
 
   endGame (guildId) {
-    Game.players.forEach(player => {
+    this.getGame(guildId).players.forEach(player => {
         player.member.voice.setMute(false)
     })
     

--- a/src/GameManager.js
+++ b/src/GameManager.js
@@ -15,6 +15,10 @@ class GameManager {
   }
 
   endGame (guildId) {
+    Game.players.forEach(player => {
+        player.member.voice.setMute(false)
+    })
+    
     console.log(`Ending game on ${guildId}`)
     return this.games.delete(guildId)
   }


### PR DESCRIPTION
I noticed that when we use the command 'endgame' the players kept muted. Then I'm adding this code to fix that. I didn't test.