### PR TITLE
Add command to set the color of a player while in game

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 | `,lobby` | `,lb` | Sets the stage to Lobby, marks everyone as alive and unmutes them |
 | `,newgame` | `,ng` | Starts a new game |
 | `,players` | `,p` | Lists all players in the current game |
+| `,setcolor` | `,sc`, `,changecolor`, `,cc` | Set the color of a player in your game |
 | `,sync` |  | Lets you control the bot through your phone |
 | `,tasks` | `,ts` | Sets the stage to tasks and mutes everyone |
 

--- a/src/Game.js
+++ b/src/Game.js
@@ -100,6 +100,12 @@ class Game {
     this.updatePlayerMute(player)
   }
 
+  setPlayerColor (member, color) {
+    const player = this.getPlayer(member)
+    player.setColor(color)
+    this.sendStateUpdate()
+  }
+
   isColorOccupied (color) {
     return !!this.getPlayerByColor(color.toLowerCase())
   }

--- a/src/commands/setcolor.js
+++ b/src/commands/setcolor.js
@@ -1,0 +1,37 @@
+const Command = require('../Command')
+const Utils = require('../Utils')
+
+const ColorRequirement = require('../ColorRequirement')
+const GameExistenceRequirement = require('../GameExistenceRequirement')
+const GameParticipationRequirement = require('../GameParticipationRequirement')
+
+module.exports = class SetColor extends Command {
+  constructor () {
+    super({
+      name: 'setcolor',
+      aliases: [ 'sc', 'changecolor', 'cc' ],
+      usage: '<color> <@mention>',
+      description: 'Set the color of a player in your game',
+
+      voiceChannelOnly: true,
+      gameExistenceRequirement: GameExistenceRequirement.GAME,
+      targetGameParticipationRequirement: GameParticipationRequirement.PARTICIPATING,
+      colorRequirement: ColorRequirement.AVAILABLE,
+      voicePermissionRequirement: [ 'MUTE_MEMBERS' ],
+      requiresTarget: true,
+      new: true
+    })
+  }
+
+  run ({ message, game, emojis, target }) {
+    if (message.mentions.members.size < 1) return message.channel.send(``)
+    const player = game.getPlayer(target)
+    const color = message.content.split(' ')[1].toLowerCase()
+
+    const previousColor = player.color
+    const previousEmoji = Utils.getPlayerEmoji(player, emojis)
+    
+    game.setPlayerColor(target, color)
+    message.channel.send(`You changed the color of **${target.user.tag}** from ${previousEmoji} \`${previousColor}\` to ${Utils.getPlayerEmoji(player, emojis)} \`${player.color}\``)
+  }
+}


### PR DESCRIPTION
I thought it would be convenient to have a command to change some players color while they are in the same game as you without removing and adding them again and without touching their Alive/Dead state.
So there is no interruption in the Mute/Deaf state of the player.

This way it would be a nice workflow to create the game using
```
,newgame
,joinall
,sync
```
Then you are able to start right away without everyone having to type `,join <color>` or one poor person having to type lots of `,forcejoin <color> <@mention>`.

The colors could then be changed later on when there is more time (e.g. when someone is dead and has all tasks finished) using:
```
,setcolor <color> <@mention>
```
The Aliases are: `,sc`, `,changecolor` and `,cc`

The response looks something like this:
```
You changed the color of **Impostor#0001** from <emoji> `green` to <emoji> `red`
```


This PR is related to #34 but implemented by command instead of the on the web panel.
The Web Panel could be added later.

Feedback is welcome!