### PR TITLE
Fix Player.setColor() by adding .toUpperCase()

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -12,7 +12,7 @@ class PlayerState {
   }
 
   setColor (color) {
-    if (!PlayerColors[color]) throw Error('Invalid player color')
+    if (!PlayerColors[color.toUpperCase()]) throw Error('Invalid player color')
     this.color = color.toLowerCase()
   }
 }


### PR DESCRIPTION
I think I found the problem causing the "lagspikes" issued by Tronage in the Discord. With the public bot I could reproduce the issue, too.

When I added the `,setcolor` command in #42 I forgot to also commit another change in Player.js:

The Object PlayerColors contains all the colors with UPPERCASE in the key and lowercase in the value.
But Player.setColor() did not account for that. Therefore the added `.toUpperCase()` should do the fix.

The "lagspikes" are in fact the Server throwing an Error because it thinks the color is not valid. I guess you have some mechanism in place, that restarts the server immediately after it crashes. The messages then get processed after the Bot is back online.

That mistake definitely goes on my hat. I did my testing with the toUpperCase and just forgot to include it in the commit. Sorry for any inconveniences!