### PR TITLE
Faster muting/deafening at stage change

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -53,14 +53,19 @@ class Game {
     if (stage.toLowerCase() === GameStages.LOBBY) this.setAliveAll(true)
     
     this.sendStateUpdate()
-    
-    const sortedPlayers = [...this.players].sort((a, b) => {
-      if (stage === GameStages.DISCUSSION || stage === GameStages.LOBBY) return a.alive - b.alive
-      if (stage === GameStages.TASKS) return b.alive - a.alive
-    })
 
-    for (const player of sortedPlayers) {
-      await this.updatePlayerMute(player)
+    const alivePlayers = this.players.filter(p => p.alive)
+    const deadPlayers = this.players.filter(p => !p.alive)
+
+    // to avoid leaking voice to players not supposed to hear it ...
+    if (stage === GameStages.DISCUSSION || stage === GameStages.LOBBY) {
+      // when switching to discussion ...
+      await Promise.all(deadPlayers.map(p => this.updatePlayerMute(p))) // first mute ghosts
+      await Promise.all(alivePlayers.map(p => this.updatePlayerMute(p))) // then allow alive players to discuss
+    } else if (stage === GameStages.TASKS) {
+      // when switching to tasks ...
+      await Promise.all(alivePlayers.map(p => this.updatePlayerMute(p))) // first mute and deafen alive players
+      await Promise.all(deadPlayers.map(p => this.updatePlayerMute(p))) // then allow ghosts to talk
     }
   }
 
@@ -143,7 +148,7 @@ class Game {
   updatePlayerMute (player) {
     if (player.member.user.bot) return
     const states = new PlayerVoiceStates(player.member.guild.me, this.voiceChannel, player, this)
-    Utils.editMember(player.member, states.getVoiceState(this.gameStage))
+    return Utils.editMember(player.member, states.getVoiceState(this.gameStage))
   }
 }
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -45,6 +45,6 @@ module.exports = class Utils {
       mute: member.voice.serverMute
     }
     if (newState.deaf === currentState.deaf && newState.mute === currentState.mute) return
-    member.edit(newState)
+    return member.edit(newState)
   }
 }


### PR DESCRIPTION
There is an issue regarding lags during the transition between game stages: #48 
I too, can see, that sometimes it takes a while for the bot to mute/unmute everyone one by one.

Looking at the code, this is the reason for such "lag":
```js
for (const player of sortedPlayers) {
      await this.updatePlayerMute(player)
}
```
The bot always waits for one user to be muted until he initiates the muting of the next user.

I can totally see, why you did this, because of the sorted array. You don't want dead players to shortly be able to talk in discussion. To achieve that, you always first muted users one by one, and then unmuted other users one by one.

First of all: the `await` here did not have any effect, because `this.updatePlayerMute(player)` and `Utils.editMember()` didn't even return a Promise.
That's fixed now.
*So to be honest, I am not sure, whether this really speeds up the transition, but see for yourself:*

Also there is a **faster** way to do so:
Using the `Promise.all()` feature in ES6 (no problem with Node.js 12) it is possible to first mute(and deafen) all players, that have to be muted, at once, wait for all of those to finish, and then unmute everyone else.
This way, the bot doesn't have to wait 10 times (for a full round), but only 2 times.
Because of the waiting (not for a timeout, but for everyone to be muted) in between, it is still guaranteed, that **no voice is leaked** to people not supposed to hear it.